### PR TITLE
Fix badge variant

### DIFF
--- a/frontend/src/components/DocumentDetailsDisplay.tsx
+++ b/frontend/src/components/DocumentDetailsDisplay.tsx
@@ -262,8 +262,8 @@ export const DocumentDetailsDisplay: React.FC<Props> = ({ documentId, projectId,
                 <CardDescription className="text-xs text-gray-500">ID: {documentDetails.id}</CardDescription>
               </div>
               <div className="flex flex-col items-end space-y-1">
-                <Badge 
-                  variant={documentDetails.status === 'processed' ? 'success' : documentDetails.status === 'error' ? 'destructive' : 'secondary'}
+                <Badge
+                  variant={documentDetails.status === 'processed' ? 'default' : documentDetails.status === 'error' ? 'destructive' : 'secondary'}
                   className="text-xs font-medium"
                 > 
                   {documentDetails.status?.toUpperCase() || "UNKNOWN"}


### PR DESCRIPTION
## Summary
- fix DocumentDetailsDisplay badge styling by using `default` variant

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.0.2/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_6849436184448331b3126722e3337fbc