### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project consists of a FastAPI backend server and a React + TypeScript front
 
 ## Stack
 
-- React+Typescript frontend with `yarn` as package manager.
+- React + TypeScript frontend with `yarn` as package manager.
 - Python FastAPI server with `uv` as package manager.
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- fix the wording around React + TypeScript in the stack description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684950cd9fa48331baaf4357dc91ad31