### PR TITLE
Fix backend venv activation path

### DIFF
--- a/backend/install.sh
+++ b/backend/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 uv venv
-source ./venv/bin/activate
+source .venv/bin/activate
 uv pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- switch backend/install.sh to source `.venv/bin/activate`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684951024e6c8331b8c48d0c95c0155a