### PR TITLE
Read Supabase config from env

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,3 +48,16 @@ export default tseslint.config({
   },
 })
 ```
+
+## Environment Variables
+
+The application expects Supabase credentials to be provided at build time. Add
+the following variables to your `.env` file in the `frontend` directory:
+
+```bash
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
+
+Vite exposes these variables through `import.meta.env`, allowing the frontend to
+connect to your Supabase instance.

--- a/frontend/src/utils/supabaseConfig.ts
+++ b/frontend/src/utils/supabaseConfig.ts
@@ -1,13 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 
-// Use the environment variables provided during the setup
-const supabaseUrl = "https://ytwedbxohfvlbcisoluq.supabase.co";
-// Use the public anon key
-const supabaseAnonKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inl0d2VkYnhvaGZ2bGJjaXNvbHVxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU4MzI2OTQsImV4cCI6MjA2MTQwODY5NH0.EnY50YOW1SKafnEvKe03gXlGj7scorZA5heSsSJBAH0";
+// Read the Supabase configuration from environment variables injected by Vite
+// These variables need to be prefixed with `VITE_` to be available on the
+// client. See `frontend/README.md` for details.
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.error(
-    "Supabase URL or Anon Key is missing. Make sure to set them up.",
+    "Supabase URL or Anon Key is missing. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment.",
   );
   // Optionally throw an error or handle this case as needed
 }


### PR DESCRIPTION
## Summary
- load `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `supabaseConfig`
- document the new env vars in the frontend README

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.0.2/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_684966b27a988331bba44690e78d293c