### PR TITLE
Fix production check and document env var

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,8 @@
+# Backend
+
+This directory contains the FastAPI server for Policy Pulse.
+
+The server reads the environment variable `DATABUTTON_SERVICE_TYPE` to determine
+whether it is running in a deployed service. If the variable is set to `prod`,
+`app.env.mode` is `Mode.PROD`; otherwise the server defaults to development
+mode.

--- a/backend/app/env.py
+++ b/backend/app/env.py
@@ -17,7 +17,7 @@ class Mode(str, Enum):
     PROD = "production"
 
 
-mode = Mode.PROD if os.environ.get("DATABUTTON_SERVICE_TYPE") == "prodx" else Mode.DEV
+mode = Mode.PROD if os.environ.get("DATABUTTON_SERVICE_TYPE") == "prod" else Mode.DEV
 
 __all__ = [
     "Mode",


### PR DESCRIPTION
## Summary
- check for `DATABUTTON_SERVICE_TYPE=prod` in `app.env`
- add explanation of the variable to `backend/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849671166fc83319b6c04fa3f447b3d